### PR TITLE
Add CFRunLoop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ build = "build.rs"
 
 [dependencies]
 libc = "0.2"
+mach = "0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ build = "build.rs"
 
 [dependencies]
 libc = "0.2"
-mach = "0.0"
+mach = "0.0.5"

--- a/src/base.rs
+++ b/src/base.rs
@@ -63,6 +63,17 @@ struct __CFAllocator {
 
 pub type CFAllocatorRef = *const __CFAllocator;
 
+pub type CFAllocatorAllocateCallBack = extern "C" fn(allocSize: CFIndex, hint: CFOptionFlags, info: *mut c_void)
+                                                     -> *mut c_void;
+pub type CFAllocatorCopyDescriptionCallBack = extern "C" fn(info: *const c_void) -> CFStringRef;
+pub type CFAllocatorDeallocateCallBack = extern "C" fn(ptr: *mut c_void, info: *mut c_void);
+pub type CFAllocatorPreferredSizeCallBack = extern "C" fn(size: CFIndex, hint: CFOptionFlags, info: *mut c_void)
+                                                          -> CFIndex;
+pub type CFAllocatorReallocateCallBack = extern "C" fn(ptr: *mut c_void, newSize: CFIndex, hint: CFOptionFlags,
+                                                       info: *mut c_void) -> *mut c_void;
+pub type CFAllocatorReleaseCallBack = extern "C" fn(info: *const c_void);
+pub type CFAllocatorRetainCallBack = extern "C" fn(info: *const c_void) -> *const c_void;
+
 extern "C" {
     pub static kCFAllocatorDefault: CFAllocatorRef;
     pub static kCFAllocatorSystemDefault: CFAllocatorRef;

--- a/src/date.rs
+++ b/src/date.rs
@@ -1,0 +1,4 @@
+use libc::c_double;
+
+pub type CFAbsoluteTime = CFTimeInterval;
+pub type CFTimeInterval = c_double;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,17 @@
 #![allow(non_upper_case_globals,non_snake_case)]
 
 extern crate libc;
+extern crate mach;
 
 pub use array::*;
 pub use base::*;
 pub use character_set::*;
 pub use data::*;
+pub use date::*;
 pub use dictionary::*;
 pub use locale::*;
 pub use number::*;
+pub use runloop::*;
 pub use string::*;
 
 
@@ -16,7 +19,9 @@ pub mod array;
 pub mod base;
 pub mod character_set;
 pub mod data;
+pub mod date;
 pub mod dictionary;
 pub mod locale;
 pub mod number;
+pub mod runloop;
 pub mod string;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-// TODO: remove allow(private_in_public), and fix compile errors
-#![allow(non_upper_case_globals,non_snake_case,private_in_public)]
+#![allow(non_upper_case_globals, non_snake_case)]
 
 extern crate libc;
 extern crate mach;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-#![allow(non_upper_case_globals,non_snake_case)]
+// TODO: remove allow(private_in_public), and fix compile errors
+#![allow(non_upper_case_globals,non_snake_case,private_in_public)]
 
 extern crate libc;
 extern crate mach;

--- a/src/runloop.rs
+++ b/src/runloop.rs
@@ -1,0 +1,192 @@
+use libc::c_void;
+use mach::port::mach_port_t;
+use ::{Boolean, CFAbsoluteTime, CFAllocatorRef, CFAllocatorCopyDescriptionCallBack, CFAllocatorReleaseCallBack, 
+       CFAllocatorRetainCallBack, CFArrayRef, CFHashCode, CFIndex, CFOptionFlags, CFStringRef, CFTimeInterval,
+       CFTypeID};
+
+#[repr(C)]
+struct __CFRunLoop {
+    __private: c_void
+}
+
+pub type CFRunLoopRef = *mut __CFRunLoop;
+
+pub type CFRunLoopResult = i32;
+
+pub const kCFRunLoopRunFinished: CFRunLoopResult = 1;
+pub const kCFRunLoopRunStopped: CFRunLoopResult = 2;
+pub const kCFRunLoopRunTimedOut: CFRunLoopResult = 3;
+pub const kCFRunLoopRunHandledSource: CFRunLoopResult = 4;
+
+extern "C" {
+    pub static kCFRunLoopCommonModes: CFStringRef;
+    pub static kCFRunLoopDefaultMode: CFStringRef;
+
+    pub fn CFRunLoopGetCurrent() -> CFRunLoopRef;
+    pub fn CFRunLoopGetMain() -> CFRunLoopRef;
+
+    pub fn CFRunLoopRun();
+    pub fn CFRunLoopRunInMode(mode: CFStringRef, seconds: CFTimeInterval, returnAfterSourceHandled: Boolean)
+                              -> CFRunLoopResult;
+
+    pub fn CFRunLoopWakeUp(rl: CFRunLoopRef);
+    pub fn CFRunLoopStop(rl: CFRunLoopRef);
+    pub fn CFRunLoopIsWaiting(rl: CFRunLoopRef) -> Boolean;
+
+    pub fn CFRunLoopAddSource(rl: CFRunLoopRef, source: CFRunLoopSourceRef, mode: CFStringRef);
+    pub fn CFRunLoopContainsSource(rl: CFRunLoopRef, source: CFRunLoopSourceRef, mode: CFStringRef) -> Boolean;
+    pub fn CFRunLoopRemoveSource(rl: CFRunLoopRef, source: CFRunLoopSourceRef, mode: CFStringRef);
+
+    pub fn CFRunLoopAddObserver(rl: CFRunLoopRef, observer: CFRunLoopObserverRef, mode: CFStringRef);
+    pub fn CFRunLoopContainsObserver(rl: CFRunLoopRef, source: CFRunLoopObserverRef, mode: CFStringRef) -> Boolean;
+    pub fn CFRunLoopRemoveObserver(rl: CFRunLoopRef, source: CFRunLoopObserverRef, mode: CFStringRef);
+
+    pub fn CFRunLoopAddCommonMode(rl: CFRunLoopRef, mode: CFStringRef);
+    pub fn CFRunLoopCopyAllModes(rl: CFRunLoopRef) -> CFArrayRef;
+    pub fn CFRunLoopCopyCurrentMode(rl: CFRunLoopRef) -> CFStringRef;
+
+    pub fn CFRunLoopAddTimer(rl: CFRunLoopRef, timer: CFRunLoopTimerRef, mode: CFStringRef);
+    pub fn CFRunLoopGetNextTimerFireDate(rl: CFRunLoopRef, mode: CFStringRef) -> CFAbsoluteTime;
+    pub fn CFRunLoopRemoveTimer(rl: CFRunLoopRef, timer: CFRunLoopTimerRef, mode: CFStringRef);
+    pub fn CFRunLoopContainsTimer(rl: CFRunLoopRef, timer: CFRunLoopTimerRef, mode: CFStringRef) -> Boolean;
+
+    pub fn CFRunLoopPerformBlock(rl: CFRunLoopRef, mode: CFStringRef, block: *mut c_void);
+    pub fn CFRunLoopGetTypeID() -> CFTypeID;
+}
+
+#[repr(C)]
+struct __CFRunLoopSource {
+    __private: c_void
+}
+
+pub type CFRunLoopSourceRef = *mut __CFRunLoopSource;
+
+#[repr(C)]
+pub struct CFRunLoopSourceContext {
+    pub version: CFIndex,
+    pub info: *mut c_void,
+    pub retain: CFAllocatorRetainCallBack,
+    pub release: CFAllocatorReleaseCallBack,
+    pub copyDescription: CFAllocatorCopyDescriptionCallBack,
+    pub equal: CFRunLoopEqualCallBack,
+    pub hash: CFRunLoopHashCallBack,
+    pub schedule: CFRunLoopScheduleCallBack,
+    pub cancel: CFRunLoopCancelCallBack,
+    pub perform: CFRunLoopPerformCallBack
+}
+
+#[repr(C)]
+pub struct CFRunLoopSourceContext1 {
+    pub version: CFIndex,
+    pub info: *mut c_void,
+    pub retain: CFAllocatorRetainCallBack,
+    pub release: CFAllocatorReleaseCallBack,
+    pub copyDescription: CFAllocatorCopyDescriptionCallBack,
+    pub equal: CFRunLoopEqualCallBack,
+    pub hash: CFRunLoopHashCallBack,
+    pub getPort: CFRunLoopGetPortCallBack,
+    pub perform: CFRunLoopMachPerformCallBack
+}
+
+pub type CFRunLoopCancelCallBack = extern "C" fn(info: *mut c_void, rl: CFRunLoopRef, mode: CFStringRef); 
+pub type CFRunLoopEqualCallBack = extern "C" fn(info0: *const c_void, info1: *const c_void) -> Boolean; 
+pub type CFRunLoopGetPortCallBack = extern "C" fn(info: *mut c_void) -> mach_port_t;
+pub type CFRunLoopHashCallBack = extern "C" fn(info: *const c_void) -> CFHashCode; 
+pub type CFRunLoopMachPerformCallBack = extern "C" fn(msg: *mut c_void, size: CFIndex, allocator: CFAllocatorRef,
+                                                      info: *mut c_void);
+pub type CFRunLoopPerformCallBack = extern "C" fn(info: *mut c_void);
+pub type CFRunLoopScheduleCallBack = extern "C" fn(info: *mut c_void, rl: CFRunLoopRef, mode: CFStringRef);
+
+extern {
+    pub fn CFRunLoopSourceCreate(allocator: CFAllocatorRef, order: CFIndex, context: *mut CFRunLoopSourceContext)
+                                 -> CFRunLoopSourceRef;
+    pub fn CFRunLoopSourceGetContext(source: CFRunLoopSourceRef, context: *mut CFRunLoopSourceContext);
+    pub fn CFRunLoopSourceGetOrder(source: CFRunLoopSourceRef) -> CFIndex;
+    pub fn CFRunLoopSourceGetTypeID() -> CFTypeID;
+    pub fn CFRunLoopSourceInvalidate(source: CFRunLoopSourceRef);
+    pub fn CFRunLoopSourceIsValid(source: CFRunLoopSourceRef) -> Boolean;
+    pub fn CFRunLoopSourceSignal(source: CFRunLoopSourceRef);
+}
+
+#[repr(C)]
+struct __CFRunLoopObserver {
+    __private: c_void
+}
+
+pub type CFRunLoopObserverRef = *mut __CFRunLoopObserver;
+
+#[repr(C)]
+pub struct CFRunLoopObserverContext {
+    pub version: CFIndex,
+    pub info: *mut c_void,
+    pub retain: CFAllocatorRetainCallBack,
+    pub release: CFAllocatorReleaseCallBack,
+    pub copyDescription: CFAllocatorCopyDescriptionCallBack
+}
+
+pub type CFRunLoopObserverCallBack = extern "C" fn(observer: CFRunLoopObserverRef, activity: CFRunLoopActivity,
+                                                   info: *mut c_void);
+
+pub type CFRunLoopActivity = u32;
+
+pub const kCFRunLoopEntry: CFRunLoopActivity = (1 << 0);
+pub const kCFRunLoopBeforeTimers: CFRunLoopActivity = (1 << 1);
+pub const kCFRunLoopBeforeSources: CFRunLoopActivity = (1 << 2);
+pub const kCFRunLoopBeforeWaiting: CFRunLoopActivity = (1 << 5);
+pub const kCFRunLoopAfterWaiting: CFRunLoopActivity = (1 << 6);
+pub const kCFRunLoopExit: CFRunLoopActivity = (1 << 7);
+pub const kCFRunLoopAllActivities: CFRunLoopActivity = 0x0FFFFFFF;
+
+extern {
+    pub fn CFRunLoopObserverCreateWithHandler(allocator: CFAllocatorRef, activities: CFOptionFlags, repeats: Boolean,
+                                              order: CFIndex, block: *mut c_void) -> CFRunLoopObserverRef;
+    pub fn CFRunLoopObserverCreate(allocator: CFAllocatorRef, activities: CFOptionFlags, repeats: Boolean,
+                                   order: CFIndex, callout: CFRunLoopObserverCallBack,
+                                   context: *mut CFRunLoopObserverContext) -> CFRunLoopObserverRef;
+
+    pub fn CFRunLoopObserverDoesRepeat(observer: CFRunLoopObserverRef) -> Boolean;
+    pub fn CFRunLoopObserverGetActivities(observer: CFRunLoopObserverRef) -> CFOptionFlags;
+    pub fn CFRunLoopObserverGetContext(observer: CFRunLoopObserverRef, context: *mut CFRunLoopObserverContext);
+    pub fn CFRunLoopObserverGetOrder(observer: CFRunLoopObserverRef) -> CFIndex;
+
+    pub fn CFRunLoopObserverGetTypeID() -> CFTypeID;
+
+    pub fn CFRunLoopObserverInvalidate(observer: CFRunLoopObserverRef);
+    pub fn CFRunLoopObserverIsValid(observer: CFRunLoopObserverRef) -> Boolean;
+}
+
+#[repr(C)]
+struct __CFRunLoopTimer {
+    __private: c_void
+}
+
+pub type CFRunLoopTimerRef = *mut __CFRunLoopTimer;
+
+pub type CFRunLoopTimerCallBack = extern "C" fn(timer: CFRunLoopTimerRef, info: *mut c_void);
+
+#[repr(C)]
+pub struct CFRunLoopTimerContext {
+    pub version: CFIndex,
+    pub info: *mut c_void,
+    pub retain: CFAllocatorRetainCallBack,
+    pub release: CFAllocatorReleaseCallBack,
+    pub copyDescription: CFAllocatorCopyDescriptionCallBack
+}
+
+extern {
+    pub fn CFRunLoopTimerCreateWithHandler(allocator: CFAllocatorRef, fireDate: CFAbsoluteTime, interval: CFTimeInterval,
+                                           flags: CFOptionFlags, order: CFIndex, block: *mut c_void) -> CFRunLoopTimerRef;
+    pub fn CFRunLoopTimerCreate(allocator: CFAllocatorRef, fireDate: CFAbsoluteTime, interval: CFTimeInterval,
+                                flags: CFOptionFlags, order: CFIndex, callout: CFRunLoopTimerCallBack,
+                                context: *mut CFRunLoopTimerContext) -> CFRunLoopTimerRef;
+
+    pub fn CFRunLoopTimerDoesRepeat(timer: CFRunLoopTimerRef) -> Boolean;
+    pub fn CFRunLoopTimerGetContext(timer: CFRunLoopTimerRef, context: *mut CFRunLoopTimerContext);
+    pub fn CFRunLoopTimerGetInterval(timer: CFRunLoopTimerRef) -> CFTimeInterval;
+    pub fn CFRunLoopTimerGetNextFireDate(timer: CFRunLoopTimerRef) -> CFAbsoluteTime;
+    pub fn CFRunLoopTimerGetOrder(timer: CFRunLoopTimerRef) -> CFIndex;
+    pub fn CFRunLoopTimerGetTypeID() -> CFTypeID;
+    pub fn CFRunLoopTimerInvalidate(timer: CFRunLoopTimerRef);
+    pub fn CFRunLoopTimerIsValid(timer: CFRunLoopTimerRef) -> Boolean;
+    pub fn CFRunLoopTimerSetNextFireDate(timer: CFRunLoopTimerRef, fireDate: CFAbsoluteTime);
+}

--- a/src/runloop.rs
+++ b/src/runloop.rs
@@ -91,7 +91,7 @@ pub struct CFRunLoopSourceContext1 {
                                info: *mut c_void) -> *mut c_void
 }
 
-extern {
+extern "C" {
     pub fn CFRunLoopSourceCreate(allocator: CFAllocatorRef, order: CFIndex, context: *mut CFRunLoopSourceContext)
                                  -> CFRunLoopSourceRef;
     pub fn CFRunLoopSourceGetContext(source: CFRunLoopSourceRef, context: *mut CFRunLoopSourceContext);
@@ -132,7 +132,7 @@ pub const kCFRunLoopAfterWaiting: CFRunLoopActivity = (1 << 6);
 pub const kCFRunLoopExit: CFRunLoopActivity = (1 << 7);
 pub const kCFRunLoopAllActivities: CFRunLoopActivity = 0x0FFFFFFF;
 
-extern {
+extern "C" {
     pub fn CFRunLoopObserverCreateWithHandler(allocator: CFAllocatorRef, activities: CFOptionFlags, repeats: Boolean,
                                               order: CFIndex, block: *mut c_void) -> CFRunLoopObserverRef;
     pub fn CFRunLoopObserverCreate(allocator: CFAllocatorRef, activities: CFOptionFlags, repeats: Boolean,
@@ -169,7 +169,7 @@ pub struct CFRunLoopTimerContext {
     pub copyDescription: CFAllocatorCopyDescriptionCallBack
 }
 
-extern {
+extern "C" {
     pub fn CFRunLoopTimerCreateWithHandler(allocator: CFAllocatorRef, fireDate: CFAbsoluteTime, interval: CFTimeInterval,
                                            flags: CFOptionFlags, order: CFIndex, block: *mut c_void) -> CFRunLoopTimerRef;
     pub fn CFRunLoopTimerCreate(allocator: CFAllocatorRef, fireDate: CFAbsoluteTime, interval: CFTimeInterval,

--- a/src/runloop.rs
+++ b/src/runloop.rs
@@ -1,11 +1,12 @@
 use libc::c_void;
 use mach::port::mach_port_t;
-use ::{Boolean, CFAbsoluteTime, CFAllocatorRef, CFAllocatorCopyDescriptionCallBack, CFAllocatorReleaseCallBack, 
+use ::{Boolean, CFAbsoluteTime, CFAllocatorRef, CFAllocatorCopyDescriptionCallBack, CFAllocatorReleaseCallBack,
        CFAllocatorRetainCallBack, CFArrayRef, CFHashCode, CFIndex, CFOptionFlags, CFStringRef, CFTimeInterval,
        CFTypeID};
 
+#[doc(hidden)]
 #[repr(C)]
-struct __CFRunLoop {
+pub struct __CFRunLoop {
     __private: c_void
 }
 
@@ -88,10 +89,10 @@ pub struct CFRunLoopSourceContext1 {
     pub perform: CFRunLoopMachPerformCallBack
 }
 
-pub type CFRunLoopCancelCallBack = extern "C" fn(info: *mut c_void, rl: CFRunLoopRef, mode: CFStringRef); 
-pub type CFRunLoopEqualCallBack = extern "C" fn(info0: *const c_void, info1: *const c_void) -> Boolean; 
+pub type CFRunLoopCancelCallBack = extern "C" fn(info: *mut c_void, rl: CFRunLoopRef, mode: CFStringRef);
+pub type CFRunLoopEqualCallBack = extern "C" fn(info0: *const c_void, info1: *const c_void) -> Boolean;
 pub type CFRunLoopGetPortCallBack = extern "C" fn(info: *mut c_void) -> mach_port_t;
-pub type CFRunLoopHashCallBack = extern "C" fn(info: *const c_void) -> CFHashCode; 
+pub type CFRunLoopHashCallBack = extern "C" fn(info: *const c_void) -> CFHashCode;
 pub type CFRunLoopMachPerformCallBack = extern "C" fn(msg: *mut c_void, size: CFIndex, allocator: CFAllocatorRef,
                                                       info: *mut c_void);
 pub type CFRunLoopPerformCallBack = extern "C" fn(info: *mut c_void);


### PR DESCRIPTION
This also required defining some CFAllocator callback types, and some cf definitions from (CFDate), which I will add to in a future commit. Also, block parameters are passed as pointer, because the `block` crate (https://crates.io/crates/block) is not repr(C) safe.

Hope this is good to merge :-)
