### PR TITLE
Fix public_in_private warnings

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -21,8 +21,9 @@ pub struct CFArrayCallBacks {
 
 pub type CFArrayApplierFunction = extern "C" fn(value: *const c_void, context: *const c_void);
 
+#[doc(hidden)]
 #[repr(C)]
-struct __CFArray {
+pub struct __CFArray {
     __private: c_void,
 }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -33,8 +33,9 @@ pub type CFIndex = c_long;
 
 pub type CFTypeRef = *const c_void;
 
+#[doc(hidden)]
 #[repr(C)]
-struct __CFString {
+pub struct __CFString {
     __private: c_void,
 }
 
@@ -56,8 +57,9 @@ pub struct CFRange {
     pub length: CFIndex
 }
 
+#[doc(hidden)]
 #[repr(C)]
-struct __CFAllocator {
+pub struct __CFAllocator {
     __private: c_void,
 }
 

--- a/src/character_set.rs
+++ b/src/character_set.rs
@@ -2,8 +2,9 @@
 
 use libc::c_void;
 
+#[doc(hidden)]
 #[repr(C)]
-struct __CFCharacterSet {
+pub struct __CFCharacterSet {
     __private: c_void,
 }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -4,8 +4,9 @@ use libc::c_void;
 
 use base::*;
 
+#[doc(hidden)]
 #[repr(C)]
-struct __CFData {
+pub struct __CFData {
     __private: c_void,
 }
 

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -31,8 +31,9 @@ pub struct CFDictionaryValueCallBacks {
     pub equal:           CFDictionaryEqualCallBack
 }
 
+#[doc(hidden)]
 #[repr(C)]
-struct __CFDictionary {
+pub struct __CFDictionary {
     __private: c_void,
 }
 

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -2,8 +2,9 @@
 
 use libc::c_void;
 
+#[doc(hidden)]
 #[repr(C)]
-struct __CFLocale {
+pub struct __CFLocale {
     __private: c_void,
 }
 

--- a/src/number.rs
+++ b/src/number.rs
@@ -4,8 +4,9 @@ use libc::c_void;
 
 use base::*;
 
+#[doc(hidden)]
 #[repr(C)]
-struct __CFBoolean {
+pub struct __CFBoolean {
     __private: c_void,
 }
 
@@ -35,8 +36,9 @@ pub const kCFNumberNSIntegerType: CFNumberType = 15;
 pub const kCFNumberCGFloatType: CFNumberType = 16;
 pub const kCFNumberMaxType: CFNumberType = 16;
 
+#[doc(hidden)]
 #[repr(C)]
-struct __CFNumber {
+pub struct __CFNumber {
     __private: c_void,
 }
 


### PR DESCRIPTION
Opaque types are now public, but are annotated with doc(hidden) to hide them in rustdoc.
