### PR TITLE
Bump version number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "CoreFoundation-sys"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["David Cuddeback <david.cuddeback@gmail.com>"]
 description = "FFI bindings for CoreFoundation"
 license = "MIT"


### PR DESCRIPTION
Version 0.1.3 fails to build because of the public/private type problem addressed in a previous commit.