### PR TITLE
migrate from mach to mach2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ build = "build.rs"
 
 [dependencies]
 libc = "0.2"
-mach = "0.1.0"
+mach2 = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(non_upper_case_globals, non_snake_case)]
 
 extern crate libc;
-extern crate mach;
+extern crate mach2;
 
 pub use array::*;
 pub use base::*;

--- a/src/runloop.rs
+++ b/src/runloop.rs
@@ -1,5 +1,5 @@
 use libc::c_void;
-use mach::port::mach_port_t;
+use mach2::port::mach_port_t;
 use ::{Boolean, CFAbsoluteTime, CFAllocatorRef, CFAllocatorCopyDescriptionCallBack, CFAllocatorReleaseCallBack,
        CFAllocatorRetainCallBack, CFArrayRef, CFHashCode, CFIndex, CFOptionFlags, CFStringRef, CFTimeInterval,
        CFTypeID, CFTypeRef};


### PR DESCRIPTION
According to RUSTSEC-2020-0168 [1] mach is unmaintained and mach2 is the "go-to" alternative. Therefore migrate to mach2.

[1] https://github.com/heim-rs/heim/issues/367